### PR TITLE
 Remove variables t while keeping same behaviour in fibonacci procedures

### DIFF
--- a/Fiboncacci/proc_avec_dbms.sql
+++ b/Fiboncacci/proc_avec_dbms.sql
@@ -3,7 +3,6 @@ fs1 number := 0;
 fs2 number := 1;
 fs3 number;
 cnt number default 0;
-t number;
 begin
 dbms_output.put_line(fs1);
 dbms_output.put_line(fs2);
@@ -11,16 +10,15 @@ while cnt!= n-2
 loop
   fs3:=fs1+fs2;
   dbms_output.put_line(fs3);
-  t:=fs2;
+  fs1:=fs2;
   fs2:=fs3;
-  fs1:=t;
   cnt:=cnt+1;
 end loop;
 exception
 when others then
 dbms_output.put_line(sqlerrm);
 end;
-
+/
 /*APPEL
-EXECUTE Fibonacci_Series(20)
+EXECUTE Fibonacci_Series(20);
 */

--- a/Fiboncacci/proc_avec_in.sql
+++ b/Fiboncacci/proc_avec_in.sql
@@ -3,21 +3,20 @@ fs1 number := 0;
 fs2 number := 1;
 fs3 number;
 cnt number default 0;
-t number;
 begin
 while cnt!= n-2
 loop
 fs3:=fs1+fs2;
 r:=fs3;
-t:=fs2;
+fs1:=fs2;
 fs2:=fs3;
-fs1:=t;
 cnt:=cnt+1;
 end loop;
 exception
 when others then
 dbms_output.put_line(sqlerrm);
 end;
+/
 
 /* APPEL 
 var v NUMBER;


### PR DESCRIPTION
In both procedures, the t variable had no use since there was no swapping between variables.
The use of a temporary variable would have been needed in an case like this: 
  a:=1;  b:=2;
  temp:=a;  a:=b;  b:=temp;
  a:=2;  b:=1;

Also, Add a "/" to the end of procedure to allow for multiple request in a go and for future reference for students.